### PR TITLE
Fix Infrastructure as Code workflow triggers and permissions

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -2,7 +2,7 @@ name: Infrastructure as Code
 
 on:
   push:
-    branches: ['**']
+    branches: [main]
   workflow_dispatch:
     inputs:
       action:
@@ -20,7 +20,7 @@ env:
   WORKING_DIR: infrastructure/terraform
 
 permissions:
-  contents: read
+  contents: write  # Required for creating commit comments
   pull-requests: write
   id-token: write  # Required for Workload Identity Federation
 


### PR DESCRIPTION
- Limit workflow to run only on push to main branch
- Add contents:write permission to allow creating commit comments

This resolves the 403 "Resource not accessible by integration" error when the workflow tries to post infrastructure details as a commit comment.