### PR TITLE
Debug push pipeline failure

### DIFF
--- a/fellspiral/site/src/scripts/cards.js
+++ b/fellspiral/site/src/scripts/cards.js
@@ -60,7 +60,6 @@ async function loadCards() {
       state.cards = cards;
     } else {
       // If no cards in Firestore, seed from JSON data
-      console.log('No cards found in Firestore, seeding from rules.md data...');
       await importCardsFromData(cardsData);
       state.cards = await getAllCards();
     }


### PR DESCRIPTION
The push pipeline was failing on main because the local tests detected a console.log statement in fellspiral/site/src/scripts/cards.js. The lint check in run-local-tests.sh enforces no console.log statements in production code.

Removed the informational console.log from the Firestore seeding logic as it was unnecessary for production.