### PR TITLE
Claude appearance updates

### DIFF
--- a/claudetool/verify_gcp_credentials.sh
+++ b/claudetool/verify_gcp_credentials.sh
@@ -12,7 +12,7 @@ echo ""
 
 # Step 1: Check credentials exist
 echo "[1/6] Checking GOOGLE_APPLICATION_CREDENTIALS_JSON environment variable..."
-if env | grep -q "export GOOGLE_APPLICATION_CREDENTIALS_JSON"; then
+if env | grep -q "GOOGLE_APPLICATION_CREDENTIALS_JSON"; then
     echo "✓ GOOGLE_APPLICATION_CREDENTIALS_JSON is set"
 else
     echo "✗ GOOGLE_APPLICATION_CREDENTIALS_JSON is not set"
@@ -22,7 +22,7 @@ echo ""
 
 # Step 2: Parse and validate JSON
 echo "[2/6] Parsing and validating credentials JSON..."
-env | grep "export GOOGLE_APPLICATION_CREDENTIALS_JSON" | sed 's/export GOOGLE_APPLICATION_CREDENTIALS_JSON=//' | sed "s/^'//" | sed "s/'$//" > /tmp/gcp_creds.json
+env | grep "GOOGLE_APPLICATION_CREDENTIALS_JSON" | sed 's/GOOGLE_APPLICATION_CREDENTIALS_JSON=//' | sed "s/^'//" | sed "s/'$//" > /tmp/gcp_creds.json
 
 PROJECT_ID=$(jq -r '.project_id' /tmp/gcp_creds.json)
 CLIENT_EMAIL=$(jq -r '.client_email' /tmp/gcp_creds.json)


### PR DESCRIPTION
The script was checking for "export GOOGLE_APPLICATION_CREDENTIALS_JSON" in env output, but env doesn't include the "export" prefix. This caused the script to incorrectly report that the environment variable was not set.

Fixed both the initial check (line 15) and the JSON parsing step (line 25) to grep for "GOOGLE_APPLICATION_CREDENTIALS_JSON" without the "export" prefix.

Verified the script now works correctly and successfully validates GCP credentials.