### PR TITLE
Debug Claude failing with G

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,13 @@ Creates site structure, tests, and manual deploy workflow. See "Adding Sites to 
 
 ### GCP Tools
 
-**`get_gcp_token.sh`** - Generate/cache GCP OAuth2 token
+**`gcpcurl`** - Authenticated GCP API requests (RECOMMENDED)
+```bash
+./claudetool/gcpcurl <url> [curl-options]
+```
+Handles authentication automatically. Use this instead of manual curl commands.
+
+**`get_gcp_token.sh`** - Generate/cache GCP OAuth2 token (for advanced use)
 ```bash
 source claudetool/get_gcp_token.sh 2>/dev/null  # Sets $GCP_ACCESS_TOKEN
 ```
@@ -46,10 +52,23 @@ curl -H "Authorization: token $GITHUB_TOKEN" \
 **IMPORTANT - Auth troubleshooting:** Use `Authorization: token` not `Bearer`. Token does not expire during sessions - if auth fails, check header format first, not token validity.
 
 ### GCP API
+
+**Use `gcpcurl` for all GCP API requests:**
+```bash
+# List Cloud Run services
+./claudetool/gcpcurl "https://run.googleapis.com/v2/projects/chalanding/locations/us-central1/services"
+
+# Check storage bucket
+./claudetool/gcpcurl "https://storage.googleapis.com/storage/v1/b/rml-media"
+
+# With additional curl options
+./claudetool/gcpcurl "https://..." -X POST -d '{"key":"value"}'
+```
+
+**Advanced:** Manual token management (only if gcpcurl doesn't meet your needs)
 ```bash
 source claudetool/get_gcp_token.sh 2>/dev/null
-curl -H "Authorization: Bearer $GCP_ACCESS_TOKEN" \
-  "https://run.googleapis.com/v2/projects/$GCP_PROJECT_ID/locations/us-central1/services"
+curl -s -H "Authorization: Bearer $GCP_ACCESS_TOKEN" "https://..."
 ```
 
 Environment provides `GOOGLE_APPLICATION_CREDENTIALS_JSON` and `GCP_PROJECT_ID=chalanding`.

--- a/claudetool/gcpcurl
+++ b/claudetool/gcpcurl
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Wrapper for making authenticated GCP API requests
+# Usage: gcpcurl <url> [curl options...]
+# Example: gcpcurl https://storage.googleapis.com/storage/v1/b/rml-media
+
+if [ -z "$1" ]; then
+    echo "Usage: gcpcurl <url> [curl options...]" >&2
+    echo "" >&2
+    echo "Examples:" >&2
+    echo "  gcpcurl https://storage.googleapis.com/storage/v1/b/rml-media" >&2
+    echo "  gcpcurl https://run.googleapis.com/v2/projects/chalanding/locations/us-central1/services" >&2
+    exit 1
+fi
+
+URL="$1"
+shift  # Remove URL from args, rest are curl options
+
+# Get token (suppress all stderr output)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/get_gcp_token.sh" 2>/dev/null || {
+    # If sourcing failed, try again with errors visible
+    echo "Error getting GCP token:" >&2
+    source "$SCRIPT_DIR/get_gcp_token.sh"
+    exit 1
+}
+
+# Verify token is set
+if [ -z "$GCP_ACCESS_TOKEN" ] || [ "$GCP_ACCESS_TOKEN" = "null" ]; then
+    echo "Error: GCP_ACCESS_TOKEN not set" >&2
+    exit 1
+fi
+
+# Make the request
+exec curl -s -H "Authorization: Bearer $GCP_ACCESS_TOKEN" "$@" "$URL"

--- a/claudetool/get_gcp_token.sh
+++ b/claudetool/get_gcp_token.sh
@@ -16,7 +16,8 @@ create_token() {
         echo "Error: GOOGLE_APPLICATION_CREDENTIALS_JSON environment variable not set" >&2
         return 1
     fi
-    echo "$GOOGLE_APPLICATION_CREDENTIALS_JSON" > "$CREDS_FILE"
+    # Strip leading/trailing single quotes if present
+    echo "$GOOGLE_APPLICATION_CREDENTIALS_JSON" | sed "s/^'//" | sed "s/'$//" > "$CREDS_FILE"
 
     # Extract private key
     jq -r '.private_key' "$CREDS_FILE" > /tmp/private_key.pem


### PR DESCRIPTION
Problems fixed:
- get_gcp_token.sh failed when GOOGLE_APPLICATION_CREDENTIALS_JSON had surrounding single quotes (now strips them like verify script)
- Manual curl commands were error-prone and verbose

Improvements:
- New gcpcurl tool handles authentication automatically
- Updated CLAUDE.md to recommend gcpcurl over manual token management
- Clearer, more concise GCP API instructions

The original failing command now works:
  source claudetool/get_gcp_token.sh 2>/dev/null && \ curl -s -H "Authorization: Bearer $GCP_ACCESS_TOKEN" \ "https://storage.googleapis.com/storage/v1/b/rml-media"

But the recommended approach is now simply:
  ./claudetool/gcpcurl "https://storage.googleapis.com/storage/v1/b/rml-media"