### PR TITLE
Simplify conditional payload construction in create-deployment action

### DIFF
--- a/.github/actions/create-deployment/action.yml
+++ b/.github/actions/create-deployment/action.yml
@@ -68,49 +68,27 @@ runs:
         echo "::notice::Deploying ${SITE_NAME} from branch ${BRANCH_NAME} to ${ENVIRONMENT} environment"
 
         # Build JSON payload with required_contexts: []
-        if [ "$TRANSIENT_ENV" = "true" ]; then
-          set +e  # Disable exit on error to capture exit code
-          PAYLOAD=$(jq -n \
-            --arg ref "${{ github.event.pull_request.head.sha || github.sha }}" \
-            --arg environment "${ENVIRONMENT}" \
-            --arg description "${DESCRIPTION}" \
-            '{
-              ref: $ref,
-              environment: $environment,
-              description: $description,
-              auto_merge: false,
-              required_contexts: [],
-              transient_environment: true
-            }' 2>&1)
-          JQ_EXIT_CODE=$?
-          set -e  # Re-enable exit on error
+        # Use jq conditional to include transient_environment only when true
+        set +e  # Disable exit on error to capture exit code
+        PAYLOAD=$(jq -n \
+          --arg ref "${{ github.event.pull_request.head.sha || github.sha }}" \
+          --arg environment "${ENVIRONMENT}" \
+          --arg description "${DESCRIPTION}" \
+          --argjson transient "${TRANSIENT_ENV}" \
+          '{
+            ref: $ref,
+            environment: $environment,
+            description: $description,
+            auto_merge: false,
+            required_contexts: []
+          } + if $transient then {transient_environment: true} else {} end' 2>&1)
+        JQ_EXIT_CODE=$?
+        set -e  # Re-enable exit on error
 
-          if [ $JQ_EXIT_CODE -ne 0 ]; then
-            echo "::error::Failed to construct deployment payload with jq"
-            echo "$PAYLOAD"
-            exit 1
-          fi
-        else
-          set +e  # Disable exit on error to capture exit code
-          PAYLOAD=$(jq -n \
-            --arg ref "${{ github.event.pull_request.head.sha || github.sha }}" \
-            --arg environment "${ENVIRONMENT}" \
-            --arg description "${DESCRIPTION}" \
-            '{
-              ref: $ref,
-              environment: $environment,
-              description: $description,
-              auto_merge: false,
-              required_contexts: []
-            }' 2>&1)
-          JQ_EXIT_CODE=$?
-          set -e  # Re-enable exit on error
-
-          if [ $JQ_EXIT_CODE -ne 0 ]; then
-            echo "::error::Failed to construct deployment payload with jq"
-            echo "$PAYLOAD"
-            exit 1
-          fi
+        if [ $JQ_EXIT_CODE -ne 0 ]; then
+          echo "::error::Failed to construct deployment payload with jq"
+          echo "$PAYLOAD"
+          exit 1
         fi
 
         # Validate payload is not empty


### PR DESCRIPTION
## Summary

This PR simplifies the conditional payload construction in the `create-deployment` GitHub Action by replacing duplicated if/else blocks with a single jq command using conditional syntax.

## Changes

- **File**: `.github/actions/create-deployment/action.yml`
- **Lines removed**: 43 (duplicated if/else logic)
- **Lines added**: 21 (simplified jq conditional)
- **Net reduction**: 22 lines

## Technical Details

The previous implementation had two separate conditional blocks constructing the payload differently based on the transient environment flag. The new approach uses jq's conditional merging (`if $transient then {transient_environment: true} else {} end`) to conditionally include the `transient_environment: true` field only when needed.

**Before**: 44-line payload construction with duplicated object creation
**After**: Single 13-line jq command with conditional merging

## Testing

- Maintains backward compatibility
- Transient environment flag is correctly set based on branch name (main = production, else = test)
- Payload structure remains identical

Fixes #161

---
*Created with Claude Code*