### PR TITLE
Fix misleading print tests comment in push-feature.yml

### DIFF
--- a/.github/workflows/push-feature.yml
+++ b/.github/workflows/push-feature.yml
@@ -206,8 +206,6 @@ jobs:
       - name: Test ${{ matrix.site }}
         run: ./infrastructure/scripts/run-local-tests.sh ${{ matrix.site }}
 
-      # Print tests are handled separately in deploy-print job
-
   # ==================== Step 2: Deploy Sites to Firebase Hosting ====================
   deploy-fellspiral:
     name: Deploy Fellspiral (Preview)


### PR DESCRIPTION
## Summary

Removed the misleading comment on line 209 in `.github/workflows/push-feature.yml` that stated "Print tests are handled separately in deploy-print job".

## Why

This comment was incorrect because:
- The `deploy-print` job only deploys to Firebase Hosting
- It does not run any tests
- The comment was creating confusion about what tests are executed during the workflow

## Changes

- Deleted the misleading comment from `.github/workflows/push-feature.yml` (lines 209-210)

Closes #159