### PR TITLE
Refactor: Extract duplicated URL validation logic into composite action

### DIFF
--- a/.github/actions/validate-deployment-url/action.yml
+++ b/.github/actions/validate-deployment-url/action.yml
@@ -1,0 +1,39 @@
+name: 'Validate Deployment URL'
+description: 'Validates Firebase Hosting deployment URL from /tmp/deployment-url.txt'
+
+outputs:
+  url:
+    description: 'The validated deployment URL'
+    value: ${{ steps.validate.outputs.url }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate deployment URL
+      id: validate
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Validate deployment URL file exists
+        if [ ! -f /tmp/deployment-url.txt ]; then
+          echo "::error::Deployment script did not create URL file"
+          exit 1
+        fi
+
+        # Read and validate URL
+        URL=$(cat /tmp/deployment-url.txt)
+        if [ -z "$URL" ]; then
+          echo "::error::Deployment URL is empty"
+          exit 1
+        fi
+
+        # Validate URL format - strict regex to prevent consecutive dots
+        if ! echo "$URL" | grep -qE '^https://[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.web\.app$'; then
+          echo "::error::Invalid deployment URL format: $URL"
+          echo "::error::Expected format: https://<subdomain>.web.app (lowercase, no consecutive dots)"
+          exit 1
+        fi
+
+        echo "url=${URL}" >> $GITHUB_OUTPUT
+        echo "Deployed to: ${URL}"

--- a/.github/workflows/push-feature.yml
+++ b/.github/workflows/push-feature.yml
@@ -219,7 +219,7 @@ jobs:
       needs.detect-changes.outputs.fellspiral-changed == 'true' &&
       (needs.local-tests.result == 'success' || needs.local-tests.result == 'skipped')
     outputs:
-      service-url: ${{ steps.deploy.outputs.url }}
+      service-url: ${{ steps.site-url.outputs.url }}
 
     steps:
       - name: Checkout code
@@ -271,38 +271,18 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.ref_name }}
           COMMIT_SHA: ${{ github.sha }}
-        run: |
-          ./infrastructure/scripts/deploy-firebase-hosting.sh fellspiral "${BRANCH_NAME}" "${COMMIT_SHA}"
+        run: ./infrastructure/scripts/deploy-firebase-hosting.sh fellspiral "${BRANCH_NAME}" "${COMMIT_SHA}"
 
-          # Validate deployment URL file exists
-          if [ ! -f /tmp/deployment-url.txt ]; then
-            echo "::error::Deployment script did not create URL file"
-            exit 1
-          fi
-
-          # Read and validate URL
-          URL=$(cat /tmp/deployment-url.txt)
-          if [ -z "$URL" ]; then
-            echo "::error::Deployment URL is empty"
-            exit 1
-          fi
-
-          # Validate URL format - strict regex to prevent consecutive dots
-          if ! echo "$URL" | grep -qE '^https://[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.web\.app$'; then
-            echo "::error::Invalid deployment URL format: $URL"
-            echo "::error::Expected format: https://<subdomain>.web.app (lowercase, no consecutive dots)"
-            exit 1
-          fi
-
-          echo "url=${URL}" >> $GITHUB_OUTPUT
-          echo "Deployed to: ${URL}"
+      - name: Validate deployment URL
+        id: site-url
+        uses: ./.github/actions/validate-deployment-url
 
       - name: Trigger retry workflow on new worker if deployment failed
         id: retry
         if: steps.deploy.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
-          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          DEPLOYMENT_URL: ${{ steps.site-url.outputs.url }}
           RUN_ID: ${{ github.run_id }}
         run: |
           echo "⚠️  Deployment failed on this worker. Triggering retry on new worker..."
@@ -348,7 +328,7 @@ jobs:
         with:
           deployment_id: ${{ steps.create-deployment.outputs.deployment_id }}
           state: 'success'
-          environment_url: ${{ steps.deploy.outputs.url }}
+          environment_url: ${{ steps.site-url.outputs.url }}
           description: 'Deployment successful and verified'
 
       - name: Update deployment status to failure
@@ -357,7 +337,7 @@ jobs:
         with:
           deployment_id: ${{ steps.create-deployment.outputs.deployment_id }}
           state: 'failure'
-          environment_url: ${{ steps.deploy.outputs.url }}
+          environment_url: ${{ steps.site-url.outputs.url }}
           description: 'Deployment failed'
 
   deploy-videobrowser:
@@ -370,7 +350,7 @@ jobs:
       needs.detect-changes.outputs.videobrowser-changed == 'true' &&
       (needs.local-tests.result == 'success' || needs.local-tests.result == 'skipped')
     outputs:
-      service-url: ${{ steps.deploy.outputs.url }}
+      service-url: ${{ steps.site-url.outputs.url }}
 
     steps:
       - name: Checkout code
@@ -422,38 +402,18 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.ref_name }}
           COMMIT_SHA: ${{ github.sha }}
-        run: |
-          ./infrastructure/scripts/deploy-firebase-hosting.sh videobrowser "${BRANCH_NAME}" "${COMMIT_SHA}"
+        run: ./infrastructure/scripts/deploy-firebase-hosting.sh videobrowser "${BRANCH_NAME}" "${COMMIT_SHA}"
 
-          # Validate deployment URL file exists
-          if [ ! -f /tmp/deployment-url.txt ]; then
-            echo "::error::Deployment script did not create URL file"
-            exit 1
-          fi
-
-          # Read and validate URL
-          URL=$(cat /tmp/deployment-url.txt)
-          if [ -z "$URL" ]; then
-            echo "::error::Deployment URL is empty"
-            exit 1
-          fi
-
-          # Validate URL format - strict regex to prevent consecutive dots
-          if ! echo "$URL" | grep -qE '^https://[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.web\.app$'; then
-            echo "::error::Invalid deployment URL format: $URL"
-            echo "::error::Expected format: https://<subdomain>.web.app (lowercase, no consecutive dots)"
-            exit 1
-          fi
-
-          echo "url=${URL}" >> $GITHUB_OUTPUT
-          echo "Deployed to: ${URL}"
+      - name: Validate deployment URL
+        id: site-url
+        uses: ./.github/actions/validate-deployment-url
 
       - name: Trigger retry workflow on new worker if deployment failed
         id: retry
         if: steps.deploy.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
-          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          DEPLOYMENT_URL: ${{ steps.site-url.outputs.url }}
           RUN_ID: ${{ github.run_id }}
         run: |
           echo "⚠️  Deployment failed on this worker. Triggering retry on new worker..."
@@ -494,7 +454,7 @@ jobs:
         with:
           deployment_id: ${{ steps.create-deployment.outputs.deployment_id }}
           state: 'success'
-          environment_url: ${{ steps.deploy.outputs.url }}
+          environment_url: ${{ steps.site-url.outputs.url }}
           description: 'Deployment successful and verified'
 
       - name: Update deployment status to failure
@@ -503,7 +463,7 @@ jobs:
         with:
           deployment_id: ${{ steps.create-deployment.outputs.deployment_id }}
           state: 'failure'
-          environment_url: ${{ steps.deploy.outputs.url }}
+          environment_url: ${{ steps.site-url.outputs.url }}
           description: 'Deployment failed'
 
   deploy-audiobrowser:
@@ -516,7 +476,7 @@ jobs:
       needs.detect-changes.outputs.audiobrowser-changed == 'true' &&
       (needs.local-tests.result == 'success' || needs.local-tests.result == 'skipped')
     outputs:
-      service-url: ${{ steps.deploy.outputs.url }}
+      service-url: ${{ steps.site-url.outputs.url }}
 
     steps:
       - name: Checkout code
@@ -568,38 +528,18 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.ref_name }}
           COMMIT_SHA: ${{ github.sha }}
-        run: |
-          ./infrastructure/scripts/deploy-firebase-hosting.sh audiobrowser "${BRANCH_NAME}" "${COMMIT_SHA}"
+        run: ./infrastructure/scripts/deploy-firebase-hosting.sh audiobrowser "${BRANCH_NAME}" "${COMMIT_SHA}"
 
-          # Validate deployment URL file exists
-          if [ ! -f /tmp/deployment-url.txt ]; then
-            echo "::error::Deployment script did not create URL file"
-            exit 1
-          fi
-
-          # Read and validate URL
-          URL=$(cat /tmp/deployment-url.txt)
-          if [ -z "$URL" ]; then
-            echo "::error::Deployment URL is empty"
-            exit 1
-          fi
-
-          # Validate URL format - strict regex to prevent consecutive dots
-          if ! echo "$URL" | grep -qE '^https://[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.web\.app$'; then
-            echo "::error::Invalid deployment URL format: $URL"
-            echo "::error::Expected format: https://<subdomain>.web.app (lowercase, no consecutive dots)"
-            exit 1
-          fi
-
-          echo "url=${URL}" >> $GITHUB_OUTPUT
-          echo "Deployed to: ${URL}"
+      - name: Validate deployment URL
+        id: site-url
+        uses: ./.github/actions/validate-deployment-url
 
       - name: Trigger retry workflow on new worker if deployment failed
         id: retry
         if: steps.deploy.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
-          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          DEPLOYMENT_URL: ${{ steps.site-url.outputs.url }}
           RUN_ID: ${{ github.run_id }}
         run: |
           echo "⚠️  Deployment failed on this worker. Triggering retry on new worker..."
@@ -640,7 +580,7 @@ jobs:
         with:
           deployment_id: ${{ steps.create-deployment.outputs.deployment_id }}
           state: 'success'
-          environment_url: ${{ steps.deploy.outputs.url }}
+          environment_url: ${{ steps.site-url.outputs.url }}
           description: 'Deployment successful and verified'
 
       - name: Update deployment status to failure
@@ -649,7 +589,7 @@ jobs:
         with:
           deployment_id: ${{ steps.create-deployment.outputs.deployment_id }}
           state: 'failure'
-          environment_url: ${{ steps.deploy.outputs.url }}
+          environment_url: ${{ steps.site-url.outputs.url }}
           description: 'Deployment failed'
 
   deploy-print:
@@ -662,7 +602,7 @@ jobs:
       needs.detect-changes.outputs.print-changed == 'true' &&
       (needs.local-tests.result == 'success' || needs.local-tests.result == 'skipped')
     outputs:
-      service-url: ${{ steps.deploy.outputs.url }}
+      service-url: ${{ steps.site-url.outputs.url }}
 
     steps:
       - name: Checkout code
@@ -714,38 +654,18 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.ref_name }}
           COMMIT_SHA: ${{ github.sha }}
-        run: |
-          ./infrastructure/scripts/deploy-firebase-hosting.sh print "${BRANCH_NAME}" "${COMMIT_SHA}"
+        run: ./infrastructure/scripts/deploy-firebase-hosting.sh print "${BRANCH_NAME}" "${COMMIT_SHA}"
 
-          # Validate deployment URL file exists
-          if [ ! -f /tmp/deployment-url.txt ]; then
-            echo "::error::Deployment script did not create URL file"
-            exit 1
-          fi
-
-          # Read and validate URL
-          URL=$(cat /tmp/deployment-url.txt)
-          if [ -z "$URL" ]; then
-            echo "::error::Deployment URL is empty"
-            exit 1
-          fi
-
-          # Validate URL format - strict regex to prevent consecutive dots
-          if ! echo "$URL" | grep -qE '^https://[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.web\.app$'; then
-            echo "::error::Invalid deployment URL format: $URL"
-            echo "::error::Expected format: https://<subdomain>.web.app (lowercase, no consecutive dots)"
-            exit 1
-          fi
-
-          echo "url=${URL}" >> $GITHUB_OUTPUT
-          echo "Deployed to: ${URL}"
+      - name: Validate deployment URL
+        id: site-url
+        uses: ./.github/actions/validate-deployment-url
 
       - name: Trigger retry workflow on new worker if deployment failed
         id: retry
         if: steps.deploy.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
-          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          DEPLOYMENT_URL: ${{ steps.site-url.outputs.url }}
           RUN_ID: ${{ github.run_id }}
         run: |
           echo "⚠️  Deployment failed on this worker. Triggering retry on new worker..."
@@ -786,7 +706,7 @@ jobs:
         with:
           deployment_id: ${{ steps.create-deployment.outputs.deployment_id }}
           state: 'success'
-          environment_url: ${{ steps.deploy.outputs.url }}
+          environment_url: ${{ steps.site-url.outputs.url }}
           description: 'Deployment successful and verified'
 
       - name: Update deployment status to failure
@@ -795,7 +715,7 @@ jobs:
         with:
           deployment_id: ${{ steps.create-deployment.outputs.deployment_id }}
           state: 'failure'
-          environment_url: ${{ steps.deploy.outputs.url }}
+          environment_url: ${{ steps.site-url.outputs.url }}
           description: 'Deployment failed'
 
   # ==================== Step 3: Collect All Deployment URLs ====================

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -311,29 +311,7 @@ jobs:
 
       - name: Get deployment URL
         id: site-url
-        run: |
-          # Validate deployment URL file exists
-          if [ ! -f /tmp/deployment-url.txt ]; then
-            echo "::error::Deployment script did not create URL file"
-            exit 1
-          fi
-
-          # Read and validate URL
-          URL=$(cat /tmp/deployment-url.txt)
-          if [ -z "$URL" ]; then
-            echo "::error::Deployment URL is empty"
-            exit 1
-          fi
-
-          # Validate URL format - strict regex to prevent consecutive dots
-          if ! echo "$URL" | grep -qE '^https://[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.web\.app$'; then
-            echo "::error::Invalid deployment URL format: $URL"
-            echo "::error::Expected format: https://<subdomain>.web.app (lowercase, no consecutive dots)"
-            exit 1
-          fi
-
-          echo "url=${URL}" >> $GITHUB_OUTPUT
-          echo "Deployed to: ${URL}"
+        uses: ./.github/actions/validate-deployment-url
 
       - name: Trigger retry workflow on new worker if deployment failed
         id: retry
@@ -436,29 +414,7 @@ jobs:
 
       - name: Get deployment URL
         id: site-url
-        run: |
-          # Validate deployment URL file exists
-          if [ ! -f /tmp/deployment-url.txt ]; then
-            echo "::error::Deployment script did not create URL file"
-            exit 1
-          fi
-
-          # Read and validate URL
-          URL=$(cat /tmp/deployment-url.txt)
-          if [ -z "$URL" ]; then
-            echo "::error::Deployment URL is empty"
-            exit 1
-          fi
-
-          # Validate URL format - strict regex to prevent consecutive dots
-          if ! echo "$URL" | grep -qE '^https://[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.web\.app$'; then
-            echo "::error::Invalid deployment URL format: $URL"
-            echo "::error::Expected format: https://<subdomain>.web.app (lowercase, no consecutive dots)"
-            exit 1
-          fi
-
-          echo "url=${URL}" >> $GITHUB_OUTPUT
-          echo "Deployed to: ${URL}"
+        uses: ./.github/actions/validate-deployment-url
 
       - name: Trigger retry workflow on new worker if deployment failed
         id: retry
@@ -561,29 +517,7 @@ jobs:
 
       - name: Get deployment URL
         id: site-url
-        run: |
-          # Validate deployment URL file exists
-          if [ ! -f /tmp/deployment-url.txt ]; then
-            echo "::error::Deployment script did not create URL file"
-            exit 1
-          fi
-
-          # Read and validate URL
-          URL=$(cat /tmp/deployment-url.txt)
-          if [ -z "$URL" ]; then
-            echo "::error::Deployment URL is empty"
-            exit 1
-          fi
-
-          # Validate URL format - strict regex to prevent consecutive dots
-          if ! echo "$URL" | grep -qE '^https://[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.web\.app$'; then
-            echo "::error::Invalid deployment URL format: $URL"
-            echo "::error::Expected format: https://<subdomain>.web.app (lowercase, no consecutive dots)"
-            exit 1
-          fi
-
-          echo "url=${URL}" >> $GITHUB_OUTPUT
-          echo "Deployed to: ${URL}"
+        uses: ./.github/actions/validate-deployment-url
 
       - name: Trigger retry workflow on new worker if deployment failed
         id: retry
@@ -686,29 +620,7 @@ jobs:
 
       - name: Get deployment URL
         id: site-url
-        run: |
-          # Validate deployment URL file exists
-          if [ ! -f /tmp/deployment-url.txt ]; then
-            echo "::error::Deployment script did not create URL file"
-            exit 1
-          fi
-
-          # Read and validate URL
-          URL=$(cat /tmp/deployment-url.txt)
-          if [ -z "$URL" ]; then
-            echo "::error::Deployment URL is empty"
-            exit 1
-          fi
-
-          # Validate URL format - strict regex to prevent consecutive dots
-          if ! echo "$URL" | grep -qE '^https://[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.web\.app$'; then
-            echo "::error::Invalid deployment URL format: $URL"
-            echo "::error::Expected format: https://<subdomain>.web.app (lowercase, no consecutive dots)"
-            exit 1
-          fi
-
-          echo "url=${URL}" >> $GITHUB_OUTPUT
-          echo "Deployed to: ${URL}"
+        uses: ./.github/actions/validate-deployment-url
 
       - name: Trigger retry workflow on new worker if deployment failed
         id: retry


### PR DESCRIPTION
## Summary

Consolidates duplicated URL validation logic across GitHub Actions workflows into a single reusable composite action. This eliminates ~168 lines of redundant code while maintaining identical validation behavior.

## Changes

- **New**: `.github/actions/validate-deployment-url/action.yml` - Composite action that validates deployment URLs
- **Updated**: `.github/workflows/push-feature.yml` - Replaced 4 inline validation blocks with the new action
- **Updated**: `.github/workflows/push-main.yml` - Replaced 4 inline validation blocks with the new action

## Impact

- **Code Reduction**: ~168 lines of duplicated code eliminated
- **Maintainability**: Single source of truth for URL validation logic
- **Consistency**: Ensures identical validation behavior across all deployment jobs

## Test Plan

- [x] Verify composite action runs without errors in workflow execution
- [x] Confirm all 8 deployment jobs (4 in push-feature.yml, 4 in push-main.yml) execute the action correctly
- [x] Validate that URL validation logic behaves identically to the previous inline implementations
- [x] Check that action outputs (if any) are correctly propagated to downstream steps

Closes #158