### PR TITLE
Change tmux-tui keybinding from prefix-t to ctrl-space

### DIFF
--- a/tmux-tui/scripts/spawn.sh
+++ b/tmux-tui/scripts/spawn.sh
@@ -75,13 +75,13 @@ else
   exit 0
 fi
 
-# Run claude in the main pane ONLY for new windows (1 pane before split)
+# Run claude in the main pane ONLY when called from after-new-window hook
 # Skip if called from restart-tui.sh (TMUX_TUI_RESTART=1)
-if [ "$IS_NEW_WINDOW" = "1" ] && [ "$TMUX_TUI_RESTART" != "1" ]; then
-  echo "$(date): Running claude in CURRENT_PANE=$CURRENT_PANE (new window detected)" >> /tmp/claude/spawn-debug.log
+if [ "$TMUX_NEW_WINDOW_HOOK" = "1" ] && [ "$TMUX_TUI_RESTART" != "1" ]; then
+  echo "$(date): Running claude in CURRENT_PANE=$CURRENT_PANE (new window hook)" >> /tmp/claude/spawn-debug.log
   tmux send-keys -t "$CURRENT_PANE" "claude || exec zsh" Enter
 else
-  echo "$(date): Skipping claude (IS_NEW_WINDOW=$IS_NEW_WINDOW, TMUX_TUI_RESTART=$TMUX_TUI_RESTART)" >> /tmp/claude/spawn-debug.log
+  echo "$(date): Skipping claude (TMUX_NEW_WINDOW_HOOK=$TMUX_NEW_WINDOW_HOOK, TMUX_TUI_RESTART=$TMUX_TUI_RESTART)" >> /tmp/claude/spawn-debug.log
 fi
 
 # Return focus to original pane

--- a/tmux-tui/tmux-tui.conf
+++ b/tmux-tui/tmux-tui.conf
@@ -6,15 +6,15 @@
 # configured via Home Manager in nix/home/tmux.nix
 
 # Hook: Auto-spawn TUI in new windows
-set-hook -g after-new-window 'run-shell "$TMUX_TUI_SPAWN_SCRIPT"'
+set-hook -g after-new-window 'run-shell "TMUX_NEW_WINDOW_HOOK=1 $TMUX_TUI_SPAWN_SCRIPT"'
 
 # Hook: Update pane focus file when pane/window selection changes
 # Uses same namespace directory as alerts for fsnotify to detect
 set-hook -g after-select-pane 'run-shell "echo #{pane_id} > /tmp/claude/$(basename #{socket_path})/pane-focus"'
 set-hook -g after-select-window 'run-shell "echo #{pane_id} > /tmp/claude/$(basename #{socket_path})/pane-focus"'
 
-# Keybinding: Prefix + t to reopen TUI
-bind t run-shell "$TMUX_TUI_SPAWN_SCRIPT"
+# Keybinding: Ctrl+Space to reopen TUI
+bind-key -n C-Space run-shell "$TMUX_TUI_SPAWN_SCRIPT"
 
 # Keybinding: Prefix + B (capital B) to toggle block state
 bind B run-shell "TMUX_PANE=#{pane_id} $TMUX_TUI_INSTALL_DIR/tmux-tui-block"


### PR DESCRIPTION
## Summary

- Changed keybinding from `prefix t` to `ctrl-space` (root binding with -n flag)
- Fixed issue where manual keybinding invocation was incorrectly running `claude || exec zsh` by using TMUX_NEW_WINDOW_HOOK environment variable
- Updated spawn.sh to check TMUX_NEW_WINDOW_HOOK instead of IS_NEW_WINDOW detection

## Changes

### tmux-tui/tmux-tui.conf
- Changed keybinding from `bind t` to `bind-key -n C-Space`
- Added TMUX_NEW_WINDOW_HOOK=1 to after-new-window hook call

### tmux-tui/scripts/spawn.sh
- Updated logic to check `TMUX_NEW_WINDOW_HOOK` environment variable instead of `IS_NEW_WINDOW` detection
- Updated debug logging to reflect new hook-based detection

## Testing
This change should be tested by:
1. Creating new tmux windows and verifying the TUI spawns automatically
2. Pressing Ctrl+Space to toggle the TUI on/off
3. Verifying that `claude || exec zsh` only runs when creating new windows (hook), not when pressing Ctrl+Space manually