### PR TITLE
Remove TODO issue refresh step from commit agent

### DIFF
--- a/.claude/agents/commit.md
+++ b/.claude/agents/commit.md
@@ -11,69 +11,6 @@ You are a commit specialist. Your job is to review all changes and create one or
 
 ## Procedure
 
-### 0. Refresh TODO Issue References
-
-Before analyzing changes, update any TODO comments that reference closed issues:
-
-1. **Scan for TODO references**: Use Grep tool to find all TODO comments with issue references:
-   - Pattern: `TODO\(#\d+\)`
-   - File types: `.go`, `.ts`, `.tsx`, `.md` files
-   <!-- TODO(#305,#351): Add rationale for file type restriction
-        Why: TypeScript/Go are actively developed; excluding vendor dirs prevents noise
-        See PR review #273 for details -->
-   - Search entire repository
-   - Output mode: "content" to see the actual TODO text
-     <!-- TODO(#365): Add context filtering to prevent matching TODOs in strings/URLs -->
-     <!-- TODO(#305,#350): Add guidance to skip TODOs in non-comment contexts
-          Why: Prevents false positives when TODO appears in strings/URLs
-          See PR review #273 -->
-
-2. **For each referenced issue found**:
-   - Extract issue number from `TODO(#NNN)` pattern
-   - Check issue status: `gh issue view <number> --json state,body,title`
-   - **If command fails**: Log warning "Unable to check status for issue #NNN: <error>. Skipping this issue." and continue to next issue
-   - If issue is OPEN: skip (no action needed)
-   - If issue is CLOSED: proceed to step 3
-
-3. **Detect merge target for closed issues**:
-   - Parse issue body for merge target patterns:
-     - `Closes #NNN`
-     - `Resolves #NNN`
-     - `Fixes #NNN`
-     - `Consolidates.*#NNN`
-     - `Superseded by #NNN`
-     - `Replaced by #NNN`
-     - `Moved to #NNN`
-   - Extract the new issue number
-   - **Validate the target**: Run `gh issue view <new-number> --json state`
-   - **If target doesn't exist**: Log warning "Issue #old references closed issue but merge target #new not found. Skipping update." and skip this issue
-
-4. **Update TODO references**:
-   - If merge target found:
-     - Use Grep tool to find all files containing the old TODO reference
-     - For each file, use Edit tool to replace `TODO(#old)` with `TODO(#new)`
-     - Add explanatory comment: `TODO(#new) [was #old: <old-title>]`
-     <!-- TODO(#365) [was #351: Improve TODO refresh documentation clarity]: Add concrete format examples and truncation rules -->
-     - Stage updated files: `git add <files>`
-     <!-- TODO(#353): Document git staging behavior and selective staging implications -->
-     - Report to user: "Updated TODO(#old) → TODO(#new) in <file-count> files"
-   - If NO merge target found:
-     - Warn user: "TODO(#old) references closed issue '<title>' but no merge target found. Manual review recommended."
-     - Do NOT block commit - this is advisory only
-
-5. **Error handling**:
-   - If `gh` command fails: warn and continue (don't block commit)
-   - If Edit fails: warn and continue
-   - All errors are non-blocking - the commit should proceed
-   <!-- TODO(#352): Improve Edit failure tracking with specific error messages and success/failure counts -->
-
-6. **Skip conditions**:
-   - Skip this step if no TODO comments with issue references found
-   - Skip if not in a git repository
-   - Skip if `gh` command unavailable
-
-**Important**: This step is a helpful enhancement but should NEVER block the commit. If any errors occur, log them and proceed to the next step.
-
 ### 1. Analyze Changes
 
 Run these commands in parallel to understand the current state:


### PR DESCRIPTION
## Summary

Removes the "Refresh TODO Issue References" step (Step 0) from the commit agent per #421.

**Why:** This feature was using unnecessary tokens and GitHub API quota during every commit operation.

**What was removed:**
- Scanning for `TODO(#NNN)` patterns in code
- Checking issue status via `gh issue view`
- Auto-updating TODO references when issues are closed/merged
- Related error handling and skip conditions

## Review

All-hands review completed with 0 actionable issues:
- Code deletion was clean
- No broken references or orphaned dependencies
- Remaining commit workflow (Steps 1-4) unchanged

## Related Issues

Closes #421

Also closes as obsolete (feature removed):
- #365 - TODO Refresh: Pattern matching and documentation improvements
- #352 - Improve error handling and logging in Commit agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)