### PR TITLE
Quick Wiggum fixes: model selection and two-strike rule cleanup

### DIFF
--- a/.claude/agents/unsupervised-implement.md
+++ b/.claude/agents/unsupervised-implement.md
@@ -1,7 +1,7 @@
 ---
 name: 'unsupervised-implement'
 description: 'Autonomous implementation agent for wiggum fixes - explores, plans, and implements without user approval'
-model: opus
+model: sonnet
 color: cyan
 permissionMode: acceptEdits
 ---

--- a/wiggum-mcp-server/src/index.ts
+++ b/wiggum-mcp-server/src/index.ts
@@ -70,7 +70,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: 'wiggum_complete_all_hands',
         description:
-          'Complete all-hands review after all agents finish (both review and implementation). Reads manifests internally, applies 2-strike agent completion logic, and returns next step instructions. If all agents complete with 0 high-priority in-scope issues, marks step complete and proceeds. Otherwise returns instructions to continue iteration.',
+          'Complete all-hands review after all agents finish (both review and implementation). Reads manifests internally, counts high-priority in-scope issues, and returns next step instructions. If issue count is 0, marks step complete and proceeds. Otherwise returns instructions to continue iteration.',
         inputSchema: {
           type: 'object',
           properties: {

--- a/wiggum-mcp-server/src/tools/complete-all-hands.ts
+++ b/wiggum-mcp-server/src/tools/complete-all-hands.ts
@@ -2,7 +2,7 @@
  * Tool: wiggum_complete_all_hands
  *
  * Called after all /all-hands-review agents complete (both review and implementation).
- * Reads manifests internally, applies 2-strike logic, and returns next step instructions.
+ * Reads manifests internally, counts high-priority in-scope issues, and returns next step instructions.
  */
 
 // TODO(#1017): Consider integration tests for complete-all-hands.ts workflow

--- a/wiggum-mcp-server/src/tools/manifest-utils.integration.test.ts
+++ b/wiggum-mcp-server/src/tools/manifest-utils.integration.test.ts
@@ -558,15 +558,15 @@ describe('manifest-utils integration tests', () => {
     });
   });
 
-  describe('2-strike logic with filesystem errors', () => {
+  describe('completion determination with filesystem errors', () => {
     /**
      * These tests verify that readManifestFiles properly handles corrupted manifests
-     * and doesn't cause incorrect agent completion status.
+     * and doesn't cause incorrect completion determination.
      *
-     * When manifest reads fail during agent completion tracking:
+     * When manifest reads fail during completion tracking:
      * - Corrupted files should be skipped (logged as warning)
      * - Valid files from other agents should still be processed
-     * - Agent completion status should reflect available data
+     * - Issue counting should reflect available data
      *
      * @see pr-test-analyzer-in-scope-3 for the issue that prompted these tests
      */

--- a/wiggum-mcp-server/src/tools/manifest-utils.test.ts
+++ b/wiggum-mcp-server/src/tools/manifest-utils.test.ts
@@ -5,7 +5,7 @@
  * Tests cover agent completion tracking, manifest reading, and cleanup logic.
  */
 
-// TODO(#994): Consider adding mutation tests for 2-strike verification logic
+// TODO(#994): Consider adding mutation tests for manifest issue counting logic
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import {
@@ -1365,6 +1365,6 @@ describe('manifest-utils', () => {
   // - Merging issues from multiple manifest files per agent
   // - Cleaning up manifest files after processing
   // - Handling filesystem errors gracefully
-  // - 2-strike agent completion edge cases
+  // - Agent completion determination based on issue counts
   // - Concurrent manifest operations
 });

--- a/wiggum-mcp-server/src/tools/manifest-utils.ts
+++ b/wiggum-mcp-server/src/tools/manifest-utils.ts
@@ -496,13 +496,13 @@ export function readManifestFiles(): Map<string, AgentManifest> {
 }
 
 /**
- * Determine which agents should be marked complete (DEPRECATED - use updateAgentCompletionStatus)
+ * Determine which agents should be marked complete (DEPRECATED - use countHighPriorityInScopeIssues)
  *
  * An agent is complete if:
  * 1. No in-scope manifest exists (found zero issues), OR
  * 2. Has in-scope manifest but zero high-priority issues
  *
- * @deprecated Use updateAgentCompletionStatus instead for 2-strike completion logic
+ * @deprecated Use countHighPriorityInScopeIssues instead for completion determination
  * @param manifests - Map of agent manifests from readManifestFiles
  * @returns Array of agent names that are complete
  */


### PR DESCRIPTION
## Summary

Implements two quick fixes for Wiggum (#1068):

1. **Model Selection**: Changed unsupervised-implement agent from opus to sonnet
2. **Two-Strike Rule Cleanup**: Removed all references to legacy two-strike strategy

## Changes

### 1. Model Configuration
- Changed `unsupervised-implement` agent model from `opus` to `sonnet` in `.claude/agents/unsupervised-implement.md`
- Rationale: The agent runs entirely as opus because subagents cannot invoke nested subagents. Using sonnet reduces costs while maintaining quality for orchestration tasks.

### 2. Documentation Updates
Removed all "two-strike" rule references and replaced with simplified completion logic:

- `.claude/commands/wiggum.md`: Updated `wiggum_complete_all_hands` and `wiggum_complete_fix` sections to document simplified procedure
- `wiggum-mcp-server/src/index.ts`: Updated tool description
- `wiggum-mcp-server/src/tools/complete-all-hands.ts`: Updated comment
- `wiggum-mcp-server/src/tools/complete-all-hands.test.ts`: Updated test documentation and replaced test describe blocks
- `wiggum-mcp-server/src/tools/manifest-utils.test.ts`: Updated TODO comment
- `wiggum-mcp-server/src/tools/manifest-utils.integration.test.ts`: Updated test describe block
- `wiggum-mcp-server/src/tools/manifest-utils.ts`: Updated deprecation comment

**Simplified Procedure**: Proceed to next step when no review agents produce high priority in-scope issues (which are fixed by the implementor agent, not rejected as already fixed).

## Test Plan

- ✅ All tests pass (1367 pass, 0 fail, 4 skipped)
- ✅ No remaining "two strike" or "2-strike" references in codebase
- ✅ Pre-commit and pre-push hooks pass

## Files Modified

- `.claude/agents/unsupervised-implement.md` - Agent model config
- `.claude/commands/wiggum.md` - Command documentation  
- `wiggum-mcp-server/src/index.ts` - Tool description
- `wiggum-mcp-server/src/tools/complete-all-hands.ts` - Implementation comment
- `wiggum-mcp-server/src/tools/complete-all-hands.test.ts` - Test documentation
- `wiggum-mcp-server/src/tools/manifest-utils.test.ts` - TODO comment
- `wiggum-mcp-server/src/tools/manifest-utils.integration.test.ts` - Test describe block
- `wiggum-mcp-server/src/tools/manifest-utils.ts` - Deprecation comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)