### PR TITLE
Fix Nix CI build failure in test-special-chars-username

### DIFF
--- a/nix/home/wezterm.test.nix
+++ b/nix/home/wezterm.test.nix
@@ -99,6 +99,7 @@ let
       default_prog = true,
       native_macos_fullscreen_mode = true,
       keys = true,
+      enable_kitty_keyboard = true,
     }
 
     -- Track valid color schemes (subset - Tokyo Night is in actual WezTerm)


### PR DESCRIPTION
## Summary

- Fix CI build failure in `test-special-chars-username` Nix check
- Add `enable_kitty_keyboard = true` to valid WezTerm config keys in test mock module
- Aligns test expectations with actual WezTerm configuration from commit 5a3f156

## Problem

The Nix CI workflow was failing because the `test-special-chars-username` check couldn't validate the generated WezTerm configuration. The test's mock WezTerm module was rejecting `enable_kitty_keyboard` as an invalid configuration key.

## Solution

Updated `nix/home/wezterm.test.nix` to include `enable_kitty_keyboard = true` in the `valid_config_keys` table. This allows the mock module to properly validate WezTerm configurations that use the Kitty keyboard protocol.

## Verification

- ✅ `nix flake check --show-trace` - all checks pass
- ✅ `test-special-chars-username` derivation builds successfully
- ✅ All pre-push hooks pass

## Test plan

- [x] Local Nix build verification completed
- [ ] CI checks pass (monitored after PR creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)